### PR TITLE
Composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "wpackagist-plugin/wp-cfm": "^1.5",
     "wpackagist-plugin/wp-native-php-sessions": "^0.6.9",
     "wpackagist-theme/twentynineteen": "^1.2",
-    "wpackagist-theme/twentyseventeen": "^1.1"
+    "wpackagist-theme/twentyseventeen": "^2.1"
   },
   "require-dev": {
     "behat/mink-goutte-driver": "^1.2.1",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "composer/installers": "^1.3.0",
     "pantheon-systems/quicksilver-pushback": "^1.0.1",
-    "pantheon-systems/wordpress-composer": "^5.1",
+    "pantheon-systems/wordpress-composer": "^5.2",
     "roots/wp-password-bcrypt": "^1.0.0",
     "rvtraveller/qs-composer-installer": "^1.1",
     "vlucas/phpdotenv": "^3.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68387ca9841390a1e0a2995e985a80b2",
+    "content-hash": "4a9f7ffeaee3c5b545f386c73ae627a1",
     "packages": [
         {
             "name": "composer/installers",
@@ -205,12 +205,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/wordpress-composer.git",
-                "reference": "221f15f7b1ff9fd5ac11451e8b1963dcb4bfbb31"
+                "reference": "485ad391b9d035eeb5c41544a290a3f71c58a94a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/wordpress-composer/zipball/221f15f7b1ff9fd5ac11451e8b1963dcb4bfbb31",
-                "reference": "221f15f7b1ff9fd5ac11451e8b1963dcb4bfbb31",
+                "url": "https://api.github.com/repos/pantheon-systems/wordpress-composer/zipball/485ad391b9d035eeb5c41544a290a3f71c58a94a",
+                "reference": "485ad391b9d035eeb5c41544a290a3f71c58a94a",
                 "shasum": ""
             },
             "require": {
@@ -231,7 +231,7 @@
                 "source": "https://github.com/pantheon-systems/wordpress-composer/tree/5.2",
                 "issues": "https://github.com/pantheon-systems/wordpress-composer/issues"
             },
-            "time": "2019-05-07T23:41:14+00:00"
+            "time": "2019-05-21T21:08:43+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -423,7 +423,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -490,15 +490,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "7.3.0.1",
+            "version": "7.5-beta-4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/7.3.0.1"
+                "reference": "tags/7.5-beta-4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.7.3.0.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.7.5-beta-4.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -508,7 +508,7 @@
         },
         {
             "name": "wpackagist-plugin/lh-hsts",
-            "version": "1.24",
+            "version": "1.25",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/lh-hsts/",
@@ -516,7 +516,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/lh-hsts.zip?timestamp=1536934210"
+                "url": "https://downloads.wordpress.org/plugin/lh-hsts.zip?timestamp=1558146276"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -562,15 +562,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-cfm",
-            "version": "1.5",
+            "version": "1.5.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-cfm/",
-                "reference": "trunk"
+                "reference": "tags/1.5.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-cfm.zip?timestamp=1543344129"
+                "url": "https://downloads.wordpress.org/plugin/wp-cfm.1.5.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -616,15 +616,15 @@
         },
         {
             "name": "wpackagist-theme/twentyseventeen",
-            "version": "1.9",
+            "version": "2.2",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentyseventeen/",
-                "reference": "1.9"
+                "reference": "2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentyseventeen.1.9.zip"
+                "url": "https://downloads.wordpress.org/theme/twentyseventeen.2.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -4679,12 +4679,12 @@
             "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a9f7ffeaee3c5b545f386c73ae627a1",
+    "content-hash": "903b1b48854e577f4e581f8dded44896",
     "packages": [
         {
             "name": "composer/installers",
@@ -201,16 +201,16 @@
         },
         {
             "name": "pantheon-systems/wordpress-composer",
-            "version": "5.2",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/wordpress-composer.git",
-                "reference": "485ad391b9d035eeb5c41544a290a3f71c58a94a"
+                "reference": "2a41a60bb25a4879c1b94c4c3c5b244e9135dbca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/wordpress-composer/zipball/485ad391b9d035eeb5c41544a290a3f71c58a94a",
-                "reference": "485ad391b9d035eeb5c41544a290a3f71c58a94a",
+                "url": "https://api.github.com/repos/pantheon-systems/wordpress-composer/zipball/2a41a60bb25a4879c1b94c4c3c5b244e9135dbca",
+                "reference": "2a41a60bb25a4879c1b94c4c3c5b244e9135dbca",
                 "shasum": ""
             },
             "require": {
@@ -228,10 +228,10 @@
             ],
             "description": "WordPress for Pantheon with a composer.json file.",
             "support": {
-                "source": "https://github.com/pantheon-systems/wordpress-composer/tree/5.2",
+                "source": "https://github.com/pantheon-systems/wordpress-composer/tree/5.2.2",
                 "issues": "https://github.com/pantheon-systems/wordpress-composer/issues"
             },
-            "time": "2019-05-21T21:08:43+00:00"
+            "time": "2019-06-18T19:34:32+00:00"
         },
         {
             "name": "phpoption/phpoption",


### PR DESCRIPTION
This applies a variety of updates via the Composer workflow. The most significant is to WordPress 5.2.2, although the following plugins are also updated:

- Jetpack (to 7.5-beta4)
- LH-HSTS (to 1.25)
- WP-CFM (to 1.5.1)
- TwentySeventeen theme (to 2.2)
